### PR TITLE
-r doesn't work, reverting to -i

### DIFF
--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -62,7 +62,7 @@ class LiveCapture(Capture):
         """
         params = super(LiveCapture, self).get_parameters(packet_count=packet_count)
         # Read from STDIN
-        params += ["-r", "-"]
+        params += ["-i", "-"]
         return params
 
     def _get_dumpcap_parameters(self):


### PR DESCRIPTION
Tested on ubuntu 20.04, anaconda python 3.7.1, TShark (Wireshark) 3.2.3 (Git v3.2.3 packaged as 3.2.3-1).
https://github.com/KimiNewt/pyshark/issues/477
https://github.com/KimiNewt/pyshark/issues/299
with LiveRingCapture and -r it just crashed, as in these issues. With LiveCapture it would drop packets. With LiveRingCapture and -i it works without dropping packets. I did not run for a long period of time yet to see how long it runs without drops. My packet rate is relatively low.